### PR TITLE
Do not set picked weapons as current if they aren't usable on jetpack

### DIFF
--- a/ptpm/pickups.lua
+++ b/ptpm/pickups.lua
@@ -107,7 +107,11 @@ function givePlayerPickupWeapon(thePlayer, thePickup)
 	if getPickupType(thePickup) == 1 then 
 		changeArmor(thePlayer, getPickupAmount(thePickup))
 	else 
-		giveWeapon(thePlayer, weaponID, getPickupAmmo(thePickup), not getPedOccupiedVehicle(thePlayer) and true or false)
+		local setAsCurrent = not getPedOccupiedVehicle(thePlayer)
+		if doesPedHaveJetPack(thePlayer) then
+			setAsCurrent = getJetpackWeaponEnabled(weaponID)
+		end
+		giveWeapon(thePlayer, weaponID, getPickupAmmo(thePickup), setAsCurrent)
 	end
 	
 	playSoundFrontEnd(thePlayer, 19)


### PR DESCRIPTION
There is really annoying thing about jetpack: you can't normally pickup weapons because it automatically changes your weapon slot. Which is pointless for weapons like flamethrower that aren't usable on jetpack.