### PR TITLE
Disable quickreload glitch

### DIFF
--- a/ptpm/main_server.lua
+++ b/ptpm/main_server.lua
@@ -248,10 +248,6 @@ function onPlayerJoin()
 			-- until set == true
 		end
 	end
-	
-	-- silly mta bug
-	setGlitchEnabled( "quickreload", false )
-	setGlitchEnabled( "quickreload", true )	
 end
 addEventHandler( "onPlayerJoin", root, onPlayerJoin )
 


### PR DESCRIPTION
With this glitch there is no point of manual reloading since you can just switch weapon which is a lot faster. Also you can switch weapon if you are close to ran out of clip to avoid reload.

Is there reason why you keep it enabled?